### PR TITLE
Fix texturesPerObject > 1 with non-BaseTextures

### DIFF
--- a/packages/batch-renderer/src/BatchGeometryFactory.ts
+++ b/packages/batch-renderer/src/BatchGeometryFactory.ts
@@ -312,7 +312,7 @@ export class BatchGeometryFactory extends IBatchGeometryFactory
             {
                 _tex = tex[k];
 
-                const texUID = _tex.BaseTexture ? _tex.baseTexture.uid : _tex.uid;
+                const texUID = _tex.baseTexture ? _tex.baseTexture.uid : _tex.uid;
 
                 (this._texID as number[])[k] = batch.uidMap[texUID];
             }


### PR DESCRIPTION
I was trying to use the `BatchRendererPluginFactory` with `texturesPerObject` set to `2`, and a `textureProperty` set to a property that returned an array of two `PIXI.Texture`s, but was seeing that the `texIDAttrib` in the shader only ever containing zeros.

I tracked it down to what looks like a typo. This prevented obtaining the `BaseTexture`'s UID, which is required to build the texture ID lookup attribute. With this correction in place, the attribute is populated with the texture IDs as expected.